### PR TITLE
unsupport darkmode for markdown

### DIFF
--- a/components/lib/DescriptionEditor.tsx
+++ b/components/lib/DescriptionEditor.tsx
@@ -27,7 +27,7 @@ export const DescriptionEditor = <FV extends Record<string, any>>({
   })
 
   return (
-    <div>
+    <div data-color-mode="light">
       <div className="flex flex-col">
         <label
           style={{ display: 'inline' }}


### PR DESCRIPTION
Result:
<img width="769" alt="Skjermbilde 2022-10-20 kl  14 53 45" src="https://user-images.githubusercontent.com/55921651/196954123-af8679b5-4a2f-43ca-aa36-9ee206021280.png">

Don´t know if the text is meant to be blue or not