### PR TITLE
Access refetch queries

### DIFF
--- a/components/dataproducts/access/datasetAccess.tsx
+++ b/components/dataproducts/access/datasetAccess.tsx
@@ -18,12 +18,10 @@ import {
   Textarea,
 } from '@navikt/ds-react'
 import { GET_DATASET_ACCESS } from '../../../lib/queries/access/datasetAccess'
-import LoaderSpinner from '../../lib/spinner'
 import { ExternalLink } from '@navikt/ds-icons'
 import { GET_ACCESS_REQUESTS_FOR_DATASET } from '../../../lib/queries/accessRequest/accessRequestsForDataset'
 import { nb } from 'date-fns/locale'
 import ErrorMessage from '../../lib/error'
-import { GET_DATAPRODUCT } from '../../../lib/queries/dataproduct/dataproduct'
 
 interface AccessEntry {
   subject: string
@@ -121,7 +119,6 @@ interface a2 {
 
 interface AccessListProps {
   id: string
-  dataproductID: string
 }
 
 interface AccessModalProps {

--- a/components/dataproducts/access/datasetAccess.tsx
+++ b/components/dataproducts/access/datasetAccess.tsx
@@ -258,7 +258,7 @@ const DatasetAccess = ({ id }: AccessListProps) => {
     datasetAccessRequestsQuery.loading ||
     !datasetAccessRequestsQuery.data?.accessRequestsForDataset
   )
-    return <LoaderSpinner />
+    return <div/>
 
   const datasetAccessRequests =
     datasetAccessRequestsQuery.data?.accessRequestsForDataset
@@ -269,7 +269,7 @@ const DatasetAccess = ({ id }: AccessListProps) => {
     datasetAccessQuery.loading ||
     !datasetAccessQuery.data?.dataset.access
   )
-    return <LoaderSpinner />
+    return <div/>
 
   const access = datasetAccessQuery.data.dataset.access
 

--- a/components/dataproducts/access/datasetAccess.tsx
+++ b/components/dataproducts/access/datasetAccess.tsx
@@ -22,6 +22,7 @@ import { ExternalLink } from '@navikt/ds-icons'
 import { GET_ACCESS_REQUESTS_FOR_DATASET } from '../../../lib/queries/accessRequest/accessRequestsForDataset'
 import { nb } from 'date-fns/locale'
 import ErrorMessage from '../../lib/error'
+import { GET_DATAPRODUCT } from '../../../lib/queries/dataproduct/dataproduct'
 
 interface AccessEntry {
   subject: string
@@ -119,6 +120,7 @@ interface a2 {
 
 interface AccessListProps {
   id: string
+  dataproductID: string
   access: access[]
 }
 
@@ -235,7 +237,7 @@ const AccessModal = ({ accessEntry, action }: AccessModalProps) => {
   )
 }
 
-const DatasetAccess = ({ id, access }: AccessListProps) => {
+const DatasetAccess = ({ id, dataproductID, access }: AccessListProps) => {
   const [formError, setFormError] = useState('')
   const [revokeAccess] = useRevokeAccessMutation()
   const [approveAccessRequest] = useApproveAccessRequestMutation()
@@ -306,9 +308,9 @@ const DatasetAccess = ({ id, access }: AccessListProps) => {
         variables: { id: a.id },
         refetchQueries: [
           {
-            query: GET_DATASET_ACCESS,
+            query: GET_DATAPRODUCT,
             variables: {
-              id,
+              id: dataproductID,
             },
           },
         ],

--- a/components/dataproducts/access/newDatasetAccess.tsx
+++ b/components/dataproducts/access/newDatasetAccess.tsx
@@ -5,7 +5,6 @@ import { Controller, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { Datepicker } from "@navikt/ds-datepicker";
 import { GET_DATASET } from "../../../lib/queries/dataset/dataset";
-import { GET_DATAPRODUCT } from "../../../lib/queries/dataproduct/dataproduct";
 
 interface NewDatasetAccessProps {
     dataset: DatasetQuery["dataset"]
@@ -70,9 +69,9 @@ const NewDatasetAccess = ({dataset, setShowNewAccess}: NewDatasetAccessProps) =>
             },
             refetchQueries: [
                 {
-                    query: GET_DATAPRODUCT,
+                    query: GET_DATASET,
                     variables: {
-                        id: dataset.dataproductID,
+                        id: dataset.id,
                     },
                 },
             ]

--- a/components/dataproducts/access/newDatasetAccess.tsx
+++ b/components/dataproducts/access/newDatasetAccess.tsx
@@ -5,6 +5,7 @@ import { Controller, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { Datepicker } from "@navikt/ds-datepicker";
 import { GET_DATASET } from "../../../lib/queries/dataset/dataset";
+import { GET_DATAPRODUCT } from "../../../lib/queries/dataproduct/dataproduct";
 
 interface NewDatasetAccessProps {
     dataset: DatasetQuery["dataset"]
@@ -69,9 +70,9 @@ const NewDatasetAccess = ({dataset, setShowNewAccess}: NewDatasetAccessProps) =>
             },
             refetchQueries: [
                 {
-                    query: GET_DATASET,
+                    query: GET_DATAPRODUCT,
                     variables: {
-                        id: dataset.id,
+                        id: dataset.dataproductID,
                     },
                 },
             ]

--- a/components/dataproducts/dataset/viewDataset.tsx
+++ b/components/dataproducts/dataset/viewDataset.tsx
@@ -164,7 +164,7 @@ const ViewDataset = ({
         </div>
         {isOwner && (
           <div className="flex flex-col gap-2">
-            <DatasetAccess dataproductID={dataproduct.id} id={dataset.id} />
+            <DatasetAccess id={dataset.id} />
             <Link
               className="cursor-pointer w-fit"
               onClick={() => {

--- a/components/dataproducts/dataset/viewDataset.tsx
+++ b/components/dataproducts/dataset/viewDataset.tsx
@@ -164,7 +164,7 @@ const ViewDataset = ({
         </div>
         {isOwner && (
           <div className="flex flex-col gap-2">
-            <DatasetAccess dataproductID={dataproduct.id} id={dataset.id} access={dataset.access} />
+            <DatasetAccess dataproductID={dataproduct.id} id={dataset.id} />
             <Link
               className="cursor-pointer w-fit"
               onClick={() => {

--- a/components/dataproducts/dataset/viewDataset.tsx
+++ b/components/dataproducts/dataset/viewDataset.tsx
@@ -10,7 +10,6 @@ import {
   UserInfoDetailsQuery,
 } from '../../../lib/schema/graphql'
 import { backendHost } from '../../header/user'
-import BigQueryLogo from '../../lib/icons/bigQueryLogo'
 import KeywordPill from '../../lib/keywordList'
 import DatasetAccess from '../access/datasetAccess'
 import NewDatasetAccess from '../access/newDatasetAccess'
@@ -165,7 +164,7 @@ const ViewDataset = ({
         </div>
         {isOwner && (
           <div className="flex flex-col gap-2">
-            <DatasetAccess id={dataset.id} access={dataset.access} />
+            <DatasetAccess dataproductID={dataproduct.id} id={dataset.id} access={dataset.access} />
             <Link
               className="cursor-pointer w-fit"
               onClick={() => {


### PR DESCRIPTION
This PR fixes the refetch queries needed after adding/revoking access to a dataset. The way it was earlier access was fetched for each dataset with the dataproduct query and then refetching dataset access does not update the ui.

Not sure whether we should just fetch the entire dataproduct in the refetch query (i did so in the first commit on this branch) or if it's better to fetch dataset access for each datasets as we already do with access requests (as I ended up with).